### PR TITLE
Delay update of APIServer resource

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -50,6 +50,9 @@ local apiServer = {
       'include.release.openshift.io/single-node-developer': 'true',
       'oauth-apiserver.openshift.io/secure-token-storage': 'true',
       'release.openshift.io/create-only': 'true',
+      // Delay apply of the APIServer resource until secrets and certs are
+      // deployed and healthy
+      'argocd.argoproj.io/sync-wave': '10',
     },
   },
   spec: com.makeMergeable(params.apiServerSpec) + {

--- a/tests/golden/defaults/openshift4-api/openshift4-api/10_apiserver.yaml
+++ b/tests/golden/defaults/openshift4-api/openshift4-api/10_apiserver.yaml
@@ -2,6 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: APIServer
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: '10'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'
     oauth-apiserver.openshift.io/secure-token-storage: 'true'


### PR DESCRIPTION
Use separate ArgoCD sync wave to delay updates to APIServer resource until all secrets and certificates are deployed and healthy.

This is implemented by simply setting argocd.argoproj.io/sync-wave="10" on the APIServer resource. This is sufficient, as ArgoCD will wait with synchronizing objects in later sync waves until all objects from the previous sync wave are healthy (cf. https://argoproj.github.io/argo-cd/user-guide/sync-waves/#how-does-it-work) and the cert-manager `Certificate` resource won't appear as healthy in ArgoCD until the certificate is issued.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
