### PR TITLE
Add support for removing serving certificates

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -8,10 +8,12 @@ The parent key for all of the following parameters is `openshift4_api`.
 type:: object
 default:: `{}`
 
-`servingCerts` is the TLS cert info for serving secure traffic.
+`servingCerts` provides TLS certificates for serving API traffic.
 This is a key-value map defining multiple named certificates.
+If the parameter has value `null` no serving certificates will be configured on the API server.
 
 Each entry needs to specify which host name it matches and provide a certificate.
+Entries can have value `null`, in which case they're skipped.
 The certificate can be provided in two ways:
 
 * `secret`: The provided entry is deployed onto the cluster as a Kubernetes Secret with `type=kubernetes.io/tls`.
@@ -104,4 +106,5 @@ servingCerts:
       issuerRef:
         name: letsencrypt-production
         kind: ClusterIssuer
+  "baz": null
 ----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -108,3 +108,21 @@ servingCerts:
         kind: ClusterIssuer
   "baz": null
 ----
+
+== `apiServerSpec`
+
+[horizontal]
+type:: object
+default::
++
+[source,yaml]
+----
+audit:
+  profile: Default
+----
+
+This parameter allows users to configure the cluster's `APIServer` resource.
+The value of the parameter is used as value for field `spec` of the APIServer resource.
+The key `servingCerts.namedCertificates` is overwritten by the contents of parameter `servingCerts`.
+
+See the https://docs.openshift.com/container-platform/4.8/rest_api/config_apis/apiserver-config-openshift-io-v1.html[OpenShift API Reference docs] for all supported fields.

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -25,3 +25,4 @@ parameters:
           issuerRef:
             name: letsencrypt-production
             kind: ClusterIssuer
+      "baz": null


### PR DESCRIPTION
In some cases, users may want to remove serving certificates which are configured higher up in the hierarchy.

This PR allows removal of configurations by setting the corresponding keys to `null`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [X] Update the documentation.
- [X] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
