### PR TITLE
Add support to add custom annotations on the APIServer resource

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,6 +3,7 @@ parameters:
     =_metadata: {}
     namespace: syn-openshift4-api
     servingCerts: {}
+    apiServerAnnotations: {}
     apiServerSpec:
       audit:
         profile: 'Default'

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -56,15 +56,18 @@ local apiServer = {
   kind: 'APIServer',
   metadata: {
     name: 'cluster',
-    annotations: {
-      'include.release.openshift.io/self-managed-high-availability': 'true',
-      'include.release.openshift.io/single-node-developer': 'true',
-      'oauth-apiserver.openshift.io/secure-token-storage': 'true',
-      'release.openshift.io/create-only': 'true',
-      // Delay apply of the APIServer resource until secrets and certs are
-      // deployed and healthy
-      'argocd.argoproj.io/sync-wave': '10',
-    },
+    annotations: std.prune(
+      {
+        'oauth-apiserver.openshift.io/secure-token-storage': 'true',
+        'release.openshift.io/create-only': 'true',
+      }
+      + com.makeMergeable(params.apiServerAnnotations)
+      + {
+        // Delay apply of the APIServer resource until secrets and certs are
+        // deployed and healthy
+        'argocd.argoproj.io/sync-wave': '10',
+      }
+    ),
   },
   spec: com.makeMergeable(params.apiServerSpec) + {
     [if std.length(nonNullServingCerts) > 0 then 'servingCerts']: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -109,6 +109,28 @@ servingCerts:
   "baz": null
 ----
 
+== `apiServerAnnotations`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+Additional annotations to apply to the `APIServer` resource on the cluster.
+Users can remove annotations from the resource by setting the annotation value to `null`.
+The component applies the following annotations by default:
+
+[source,yaml]
+----
+oauth-apiserver.openshift.io/secure-token-storage: 'true',
+release.openshift.io/create-only: 'true',
+----
+
+[NOTE]
+====
+In addition to the annotations listed above, the annotation `argocd.argoproj.io/sync-wave='10'` is applied to the APIServer resource after the user-provided annotations are applied.
+This is done to ensure that the APIServer resource is configured after all certificate secrets are available in  the cluster.
+====
+
 == `apiServerSpec`
 
 [horizontal]


### PR DESCRIPTION
Also removes the annotations `include.release.openshift.io/self-managed-high-availability='true'` and
`include.release.openshift.io/single-node-developer': 'true'` from the default annotations.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
