### PR TITLE
Allow deploying ServiceMonitors to monitor OpenShift API-Servers

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,4 +10,4 @@ parameters:
 
     monitoring:
       enabled: true
-      instance: ''
+      instance: null

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,3 +7,6 @@ parameters:
     apiServerSpec:
       audit:
         profile: 'Default'
+
+    monitoring:
+      enabled: true

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,3 +10,4 @@ parameters:
 
     monitoring:
       enabled: true
+      instance: ''

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -90,5 +90,5 @@ local apiServer = {
   [if std.length(certs) > 0 then '00_certs']: certs,
   [if std.length(rawSecrets) > 0 then '00_secrets']: rawSecrets,
   '10_apiserver': apiServer,
-  [if params.monitoring.enabled && std.member(inv.applications, 'prometheus') then '20_monitoring']: (import 'monitoring.libsonnet'),
+  '20_monitoring': (import 'monitoring.libsonnet'),
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -90,4 +90,5 @@ local apiServer = {
   [if std.length(certs) > 0 then '00_certs']: certs,
   [if std.length(rawSecrets) > 0 then '00_secrets']: rawSecrets,
   '10_apiserver': apiServer,
+  [if params.monitoring.enabled then '20_monitoring']: (import 'monitoring.libsonnet'),
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -90,5 +90,5 @@ local apiServer = {
   [if std.length(certs) > 0 then '00_certs']: certs,
   [if std.length(rawSecrets) > 0 then '00_secrets']: rawSecrets,
   '10_apiserver': apiServer,
-  [if params.monitoring.enabled then '20_monitoring']: (import 'monitoring.libsonnet'),
+  [if params.monitoring.enabled && std.member(inv.applications, 'prometheus') then '20_monitoring']: (import 'monitoring.libsonnet'),
 }

--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -9,7 +9,7 @@ local params = inv.parameters.openshift4_api;
 
 local nsName = 'syn-monitoring-openshift4-api';
 
-local apiServerMonitor = function(name, selectorTargetLabel)
+local apiServerMonitor = function(name, selector)
   prom.ServiceMonitor(name) {
     metadata+: {
       namespace: nsName,
@@ -72,16 +72,16 @@ local apiServerMonitor = function(name, selectorTargetLabel)
           name,
         ],
       },
-      selector: {
-        matchLabels: {
-          [selectorTargetLabel]: name,
-        },
-      },
+      selector: selector,
     },
   };
 
 [
   prom.RegisterNamespace(kube.Namespace(nsName)),
-  apiServerMonitor('openshift-apiserver', 'prometheus'),
-  apiServerMonitor('openshift-oauth-apiserver', 'app'),
+  apiServerMonitor('openshift-apiserver', {
+    matchLabels: {
+      prometheus: 'openshift-apiserver',
+    },
+  }),
+  apiServerMonitor('openshift-oauth-apiserver', {}),
 ]

--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -1,0 +1,83 @@
+local cm = import 'lib/cert-manager.libsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local prom = import 'lib/prometheus.libsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.openshift4_api;
+
+local nsName = params.namespace + '-monitoring';
+
+[
+  prom.RegisterNamespace(kube.Namespace(nsName)),
+  prom.ServiceMonitor('api-server') {
+    metadata+: {
+      namespace: nsName,
+    },
+    spec+: {
+      endpoints: [
+        {
+          bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+          interval: '30s',
+          metricRelabelings: [
+            {
+              action: 'drop',
+              regex: 'etcd_(debugging|disk|server).*',
+              sourceLabels: [
+                '__name__',
+              ],
+            },
+            {
+              action: 'drop',
+              regex: 'apiserver_admission_controller_admission_latencies_seconds_.*',
+              sourceLabels: [
+                '__name__',
+              ],
+            },
+            {
+              action: 'drop',
+              regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
+              sourceLabels: [
+                '__name__',
+              ],
+            },
+            {
+              action: 'drop',
+              regex: 'apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)',
+              sourceLabels: [
+                '__name__',
+                'le',
+              ],
+            },
+          ],
+          port: 'https',
+          relabelings: [
+            {
+              action: 'replace',
+              replacement: 'openshift-apiserver',
+              targetLabel: 'apiserver',
+            },
+          ],
+          scheme: 'https',
+          tlsConfig: {
+            caFile: '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt',
+            certFile: '/etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.crt',
+            keyFile: '/etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.key',
+            serverName: 'api.openshift-apiserver.svc',
+          },
+        },
+      ],
+      namespaceSelector: {
+        matchNames: [
+          'openshift-apiserver',
+        ],
+      },
+      selector: {
+        matchLabels: {
+          prometheus: 'openshift-apiserver',
+        },
+      },
+    },
+  },
+]

--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -10,7 +10,7 @@ local params = inv.parameters.openshift4_api;
 local nsName = 'syn-monitoring-openshift4-api';
 
 local promInstance =
-  if params.monitoring.instance != '' then
+  if params.monitoring.instance != null then
     params.monitoring.instance
   else
     inv.parameters.prometheus.defaultInstance;

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -130,3 +130,28 @@ release.openshift.io/create-only: 'true',
 In addition to the annotations listed above, the annotation `argocd.argoproj.io/sync-wave='10'` is applied to the APIServer resource after the user-provided annotations are applied.
 This is done to ensure that the APIServer resource is configured after all certificate secrets are available in  the cluster.
 ====
+
+== `monitoring`
+
+This parameter allows users to enable the component's monitoring configuration.
+Currently the component has support for deploying custom `ServiceMonitors` on clusters which use component `prometheus` to manage a custom monitoring stack.
+
+=== `enabled`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Whether to deploy monitoring configurations.
+If this parameter is set to `true`, the component will check whether component `prometheus` is present on the cluster.
+If the component is missing, no configurations will be deployed regardless of the value of this parameter.
+
+=== `instance`
+
+[horizontal]
+type:: string
+default:: `''`
+
+This parameter can be used to indicate which custom Prometheus instance should pick up the configurations managed by the component.
+
+If the parameter is set to the empty string, the default instance configured for component `prometheus` will be used.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -150,7 +150,7 @@ If the component is missing, no configurations will be deployed regardless of th
 
 [horizontal]
 type:: string
-default:: `''`
+default:: `null`
 
 This parameter can be used to indicate which custom Prometheus instance should pick up the configurations managed by the component.
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,3 +1,6 @@
+applications:
+  - prometheus
+
 parameters:
   kapitan:
     dependencies:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -8,7 +8,7 @@ parameters:
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.1.0/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/v1.4.0/lib/prometheus.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
         output_path: vendor/lib/prometheus.libsonnet
 
   openshift4_api:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -4,6 +4,10 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.1.0/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/v1.4.0/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
   openshift4_api:
     servingCerts:
       "foo":
@@ -26,3 +30,6 @@ parameters:
             name: letsencrypt-production
             kind: ClusterIssuer
       "baz": null
+
+  prometheus:
+    defaultInstance: infra

--- a/tests/golden/defaults/openshift4-api/openshift4-api/20_monitoring.yaml
+++ b/tests/golden/defaults/openshift4-api/openshift4-api/20_monitoring.yaml
@@ -4,17 +4,17 @@ metadata:
   annotations: {}
   labels:
     monitoring.syn.tools/infra: 'true'
-    name: syn-openshift4-api-monitoring
-  name: syn-openshift4-api-monitoring
+    name: syn-monitoring-openshift4-api
+  name: syn-monitoring-openshift4-api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    name: api-server
-  name: api-server
-  namespace: syn-openshift4-api-monitoring
+    name: openshift-apiserver
+  name: openshift-apiserver
+  namespace: syn-monitoring-openshift4-api
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -54,3 +54,51 @@ spec:
   selector:
     matchLabels:
       prometheus: openshift-apiserver
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-oauth-apiserver
+  name: openshift-oauth-apiserver
+  namespace: syn-monitoring-openshift4-api
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: etcd_(debugging|disk|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_admission_controller_admission_latencies_seconds_.*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_admission_step_admission_latencies_seconds_.*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
+          sourceLabels:
+            - __name__
+            - le
+      port: https
+      relabelings:
+        - action: replace
+          replacement: openshift-oauth-apiserver
+          targetLabel: apiserver
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        certFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.crt
+        keyFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.key
+        serverName: api.openshift-oauth-apiserver.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-oauth-apiserver
+  selector:
+    matchLabels:
+      app: openshift-oauth-apiserver

--- a/tests/golden/defaults/openshift4-api/openshift4-api/20_monitoring.yaml
+++ b/tests/golden/defaults/openshift4-api/openshift4-api/20_monitoring.yaml
@@ -99,6 +99,4 @@ spec:
   namespaceSelector:
     matchNames:
       - openshift-oauth-apiserver
-  selector:
-    matchLabels:
-      app: openshift-oauth-apiserver
+  selector: {}

--- a/tests/golden/defaults/openshift4-api/openshift4-api/20_monitoring.yaml
+++ b/tests/golden/defaults/openshift4-api/openshift4-api/20_monitoring.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    monitoring.syn.tools/infra: 'true'
+    name: syn-openshift4-api-monitoring
+  name: syn-openshift4-api-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: api-server
+  name: api-server
+  namespace: syn-openshift4-api-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: etcd_(debugging|disk|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_admission_controller_admission_latencies_seconds_.*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_admission_step_admission_latencies_seconds_.*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
+          sourceLabels:
+            - __name__
+            - le
+      port: https
+      relabelings:
+        - action: replace
+          replacement: openshift-apiserver
+          targetLabel: apiserver
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        certFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.crt
+        keyFile: /etc/prometheus/secrets/ocp-metric-client-certs-monitoring/tls.key
+        serverName: api.openshift-apiserver.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-apiserver
+  selector:
+    matchLabels:
+      prometheus: openshift-apiserver


### PR DESCRIPTION
Adds ServiceMonitors for `openshift-apiserver` and `openshift-oauth-apiserver`.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
